### PR TITLE
Add autocomplete to `/example` command

### DIFF
--- a/cogs/pycord.py
+++ b/cogs/pycord.py
@@ -73,7 +73,7 @@ class Pycord(Cog):
         ]
 
     @discord.slash_command(guild_ids=[881207955029110855])
-    async def example(self, ctx, name: discord.Option(str, description="name of example to search for", autocomplete=get_example_list)):
+    async def example(self, ctx, name: discord.Option(str, description="The name of example to search for", autocomplete=get_example_list)):
         """Get the link of an example from the Pycord repository."""
         if not name.endswith(".py"):
             name = f"{name}.py"

--- a/cogs/pycord.py
+++ b/cogs/pycord.py
@@ -59,15 +59,16 @@ class Pycord(Cog):
         """Updates the cached example list with the latest contents from the repo."""
         file_url = "https://api.github.com/repos/Pycord-Development/pycord/git/trees/master?recursive=1"
         async with self.bot.http_session.get(file_url, raise_for_status=True) as response:
-            self.bot.cache["example_list"] = await response.json()
+            self.bot.cache["example_list"] = examples = await response.json()
+            return examples
 
     async def get_example_list(self, ctx: discord.AutocompleteContext):
         """Gets the latest list of example files found in the Pycord repository."""
-        if not self.bot.cache.get("example_list"):
-            await self.update_example_cache()
+        if not examples := self.bot.cache.get("example_list"):
+            examples = await self.update_example_cache()
         return [
             file["path"].partition("examples/")[2]
-            for file in self.bot.cache["example_list"]["tree"]
+            for file in examples["tree"]
             if "examples" in file["path"] and file["path"].endswith(".py") and ctx.value in file["path"]
         ]
 

--- a/cogs/pycord.py
+++ b/cogs/pycord.py
@@ -64,7 +64,7 @@ class Pycord(Cog):
 
     async def get_example_list(self, ctx: discord.AutocompleteContext):
         """Gets the latest list of example files found in the Pycord repository."""
-        if not examples := self.bot.cache.get("example_list"):
+        if not (examples := self.bot.cache.get("example_list")):
             examples = await self.update_example_cache()
         return [
             file["path"].partition("examples/")[2]

--- a/utils/bot.py
+++ b/utils/bot.py
@@ -32,7 +32,7 @@ class PycordManager(commands.Bot):
         )
 
         self.on_ready_fired = False
-        self.cache = {"afk": {}, "unmute_task": {}}
+        self.cache = {"afk": {}, "unmute_task": {}, "example_list": {}}
         self.to_load = [
             "jishaku",
             "cogs.help_command",


### PR DESCRIPTION
This adds autocomplete to the `/example` command, which should greatly aid in usability.