### PR TITLE
Add `close` command for threads

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -140,39 +140,6 @@ class Moderation(Cog):
             reason=f"{ctx.author} ({ctx.author.id}): {reason}",
         )
         await ctx.send("Unlocked this channel.")
-        
-    @discord.slash_command()
-    async def close(ctx, lock: bool=False):
-    """Allows a staff member or the user that opened the Thread to close the Thread"""
-    
-    # Check If The Channel Is A Thread
-    if type(ctx.channel) != discord.Thread:
-        return await ctx.respond("This Command Can Only Be Used In Threads", ephemeral=True)
-
-    if ctx.channel.permissions_for(ctx.author).manage_threads:
-        if lock:
-            embed = discord.Embed(description="This Thread Was Archived And Locked By A Staff Member. Please Create "
-                                              "Another Thread For More Help.",
-                                  color=0xff0000,
-                                  )
-        else:
-            embed = discord.Embed(description="This Thread Was Archived By A Staff Member, If You Have A Different "
-                                              "Problem Please Create Another Thread. If It Is The Same Problem Send "
-                                              "Another Message",
-                                  color=0xffff00,
-                                  )
-        await ctx.respond(embed=embed)
-        return await ctx.channel.archive(locked=lock)
-    elif ctx.author.id == ctx.channel.owner_id:
-        embed = discord.Embed(description="This Thread Was Archived By The User That Opened It. If You Have A "
-                                          "Question Please Open A New Thread.",
-                              color=0xffff00,
-                              )
-        await ctx.respond(embed=embed)
-        return await ctx.channel.archive(locked=False)
-    else:
-        return await ctx.respond("This Command Can Only Be Used By The Author Of The Thread Or Staff Member", 
-                                 ephemeral=True)
 
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -140,6 +140,39 @@ class Moderation(Cog):
             reason=f"{ctx.author} ({ctx.author.id}): {reason}",
         )
         await ctx.send("Unlocked this channel.")
+        
+    @discord.slash_command()
+    async def close(ctx, lock: bool=False):
+    """Allows a staff member or the user that opened the Thread to close the Thread"""
+    
+    # Check If The Channel Is A Thread
+    if type(ctx.channel) != discord.Thread:
+        return await ctx.respond("This Command Can Only Be Used In Threads", ephemeral=True)
+
+    if ctx.channel.permissions_for(ctx.author).manage_threads:
+        if lock:
+            embed = discord.Embed(description="This Thread Was Archived And Locked By A Staff Member. Please Create "
+                                              "Another Thread For More Help.",
+                                  color=0xff0000,
+                                  )
+        else:
+            embed = discord.Embed(description="This Thread Was Archived By A Staff Member, If You Have A Different "
+                                              "Problem Please Create Another Thread. If It Is The Same Problem Send "
+                                              "Another Message",
+                                  color=0xffff00,
+                                  )
+        await ctx.respond(embed=embed)
+        return await ctx.channel.archive(locked=lock)
+    elif ctx.author.id == ctx.channel.owner_id:
+        embed = discord.Embed(description="This Thread Was Archived By The User That Opened It. If You Have A "
+                                          "Question Please Open A New Thread.",
+                              color=0xffff00,
+                              )
+        await ctx.respond(embed=embed)
+        return await ctx.channel.archive(locked=False)
+    else:
+        return await ctx.respond("This Command Can Only Be Used By The Author Of The Thread Or Staff Member", 
+                                 ephemeral=True)
 
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/cogs/pycord.py
+++ b/cogs/pycord.py
@@ -92,42 +92,37 @@ class Pycord(Cog):
         )
         
     @discord.slash_command(guild_ids=[881207955029110855])
-    async def close(ctx, lock: bool = False):
-        """Allows a staff member or the user that opened the Thread to close the Thread"""
+    async def close(self, ctx: discord.ApplicationContext, lock: bool = False):
+        """Allows a staff member or the owner of the thread to close the thread"""
 
-        # Check If The Channel Is A Thread
-        if type(ctx.channel) != discord.Thread:
+        if not isinstance(ctx.channel, discord.Thread):
             return await ctx.respond(
-                "This Command Can Only Be Used In Threads", ephemeral=True
+                "This command can only be used in threads.", ephemeral=True
             )
 
         if ctx.channel.permissions_for(ctx.author).manage_threads:
             if lock:
                 embed = discord.Embed(
-                    description="This Thread Was Archived And Locked By A Staff Member. Please Create "
-                    "Another Thread For More Help.",
+                    description="This thread was archived and locked by a staff member.",
                     color=0xFF0000,
                 )
             else:
                 embed = discord.Embed(
-                    description="This Thread Was Archived By A Staff Member, If You Have A Different "
-                    "Problem Please Create Another Thread. If It Is The Same Problem Send "
-                    "Another Message",
+                    description="This thread was archived by a staff member.",
                     color=0xFFFF00,
                 )
             await ctx.respond(embed=embed)
-            return await ctx.channel.archive(locked=lock)
+            await ctx.channel.archive(locked=lock)
         elif ctx.author.id == ctx.channel.owner_id:
             embed = discord.Embed(
-                description="This Thread Was Archived By The User That Opened It. If You Have A "
-                "Question Please Open A New Thread.",
+                description="This thread was archived by the user that opened it.",
                 color=0xFFFF00,
             )
             await ctx.respond(embed=embed)
-            return await ctx.channel.archive(locked=False)
+            await ctx.channel.archive()
         else:
-            return await ctx.respond(
-                "This Command Can Only Be Used By The Author Of The Thread Or Staff Member",
+            await ctx.respond(
+                "This command can only be used by the owner of the thread or a staff member.",
                 ephemeral=True,
             )
 

--- a/cogs/pycord.py
+++ b/cogs/pycord.py
@@ -90,6 +90,46 @@ class Pycord(Cog):
                 )
             ),
         )
+        
+    @discord.slash_command(guild_ids=[881207955029110855])
+    async def close(ctx, lock: bool = False):
+        """Allows a staff member or the user that opened the Thread to close the Thread"""
+
+        # Check If The Channel Is A Thread
+        if type(ctx.channel) != discord.Thread:
+            return await ctx.respond(
+                "This Command Can Only Be Used In Threads", ephemeral=True
+            )
+
+        if ctx.channel.permissions_for(ctx.author).manage_threads:
+            if lock:
+                embed = discord.Embed(
+                    description="This Thread Was Archived And Locked By A Staff Member. Please Create "
+                    "Another Thread For More Help.",
+                    color=0xFF0000,
+                )
+            else:
+                embed = discord.Embed(
+                    description="This Thread Was Archived By A Staff Member, If You Have A Different "
+                    "Problem Please Create Another Thread. If It Is The Same Problem Send "
+                    "Another Message",
+                    color=0xFFFF00,
+                )
+            await ctx.respond(embed=embed)
+            return await ctx.channel.archive(locked=lock)
+        elif ctx.author.id == ctx.channel.owner_id:
+            embed = discord.Embed(
+                description="This Thread Was Archived By The User That Opened It. If You Have A "
+                "Question Please Open A New Thread.",
+                color=0xFFFF00,
+            )
+            await ctx.respond(embed=embed)
+            return await ctx.channel.archive(locked=False)
+        else:
+            return await ctx.respond(
+                "This Command Can Only Be Used By The Author Of The Thread Or Staff Member",
+                ephemeral=True,
+            )
 
     @command()
     @pycord_only


### PR DESCRIPTION
Allows the member that opened the thread to close it with the `close` command. Also allows members with the `manage_threads` permission to close the tread with the option of locking the thread.

Fixes #33 