### PR TITLE
Added response to no perm button press

### DIFF
--- a/cogs/gitlink.py
+++ b/cogs/gitlink.py
@@ -47,6 +47,7 @@ class Delete(discord.ui.View):
             # so Delete view works globally
             return True
         if self.user.id != interaction.user.id:  # type: ignore
+            await interaction.response.send_message("You cannot delete this!", ephemeral=True)
             return False
         return True
 


### PR DESCRIPTION
Currently, when pressing the delete button, the client will eventually timeout the response and show the ugly "This interaction failed".
This PR makes it so the bot will respond with an ephemeral message saying they can't (as to prevent the fail)