### PR TITLE
Disable the select when the timeout for the help command

### DIFF
--- a/cogs/help_command.py
+++ b/cogs/help_command.py
@@ -55,6 +55,10 @@ class HelpCommand(commands.HelpCommand):
 
         view = discord.ui.View()
         view.add_item(HelpSelect(options, self.context))
+        async def timeoutfunc(interaction):
+          view.disable_all_items() 
+        view.on_timeout = timeoutfunc
+
         await self.context.send(embed=embed, view=view)
 
     async def send_cog_help(self, cog: commands.Cog):


### PR DESCRIPTION
Have the select be disabled when the timeout occurs, it’s kind of annoying not knowing when the timeout is until you use the select and get `Interaction failed`.